### PR TITLE
Add CLI overrides for play commands

### DIFF
--- a/legged_gym/utils/helpers.py
+++ b/legged_gym/utils/helpers.py
@@ -134,6 +134,10 @@ def get_args():
         {"name": "--num_envs", "type": int, "help": "Number of environments to create. Overrides config file if provided."},
         {"name": "--seed", "type": int, "help": "Random seed. Overrides config file if provided."},
         {"name": "--max_iterations", "type": int, "help": "Maximum number of training iterations. Overrides config file if provided."},
+        {"name": "--command_lin_vel_x", "type": float, "help": "Override commanded linear velocity along x during play."},
+        {"name": "--command_lin_vel_y", "type": float, "help": "Override commanded linear velocity along y during play."},
+        {"name": "--command_heading", "type": float, "help": "Override commanded heading (rad) during play."},
+        {"name": "--command_yaw_rate", "type": float, "help": "Override commanded yaw rate (rad/s) during play. Disables heading command mode."},
     ]
     # parse arguments
     args = gymutil.parse_arguments(


### PR DESCRIPTION
## Summary
- allow python legged_gym/scripts/play.py to accept optional command overrides
- expose CLI arguments for fixed linear velocities, heading, or yaw rate
- print the fixed commands in play mode and disable heading mode when yaw-rate is specified

## Testing
- python -m compileall legged_gym/scripts/play.py legged_gym/utils/helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68d11b96a600832e845a2636763ace31