### PR TITLE
Refine G1 interaction tasks and extra actor handling

### DIFF
--- a/legged_gym/envs/g1/g1_carry_env.py
+++ b/legged_gym/envs/g1/g1_carry_env.py
@@ -1,116 +1,163 @@
 import torch
-from isaacgym import gymapi, gymtorch
+from isaacgym import gymapi
+from isaacgym.torch_utils import torch_rand_float
+
 from legged_gym.envs.g1.g1_env import G1Robot
 
+
 class G1CarryRobot(G1Robot):
-    
+
     def __init__(self, cfg, sim_params, physics_engine, sim_device, headless):
-        # 搬运任务需要2个actors: robot + box
-        self.actors_per_env = 2
+        # 每个环境额外增加 1 个搬运箱体 actor。
+        self.extra_actors_per_env = 1
         super().__init__(cfg, sim_params, physics_engine, sim_device, headless)
-        
+
+        # 额外 actor 在 root-state tensor 中的偏移量/行索引。
+        self._box_actor_offset = self.get_extra_actor_offset(0)
+        self._box_actor_rows = self.get_extra_actor_row_indices(0)
+
+    # ------------------------------------------------------------------
+    # 资产与缓存初始化
+    # ------------------------------------------------------------------
     def _create_envs(self):
         super()._create_envs()
         self._create_boxes()
-        
+
     def _create_boxes(self):
-        """创建箱子资产"""
+        """为每个环境创建可搬运的箱子 actor。"""
+
+        asset_opts = gymapi.AssetOptions()
+        asset_opts.density = (
+            100.0 if not getattr(self.cfg.box.build, "randomDensity", False) else 500.0
+        )
+
+        base_size = torch.tensor(self.cfg.box.build.baseSize, dtype=torch.float32)
+        box_asset = self.gym.create_box(
+            self.sim,
+            float(base_size[0]),
+            float(base_size[1]),
+            float(base_size[2]),
+            asset_opts,
+        )
+
+        default_pose = gymapi.Transform()
+        default_pose.p = gymapi.Vec3(0.6, 0.0, float(base_size[2] / 2.0))
+
         self.box_handles = []
-        asset_options = gymapi.AssetOptions()
-        asset_options.density = 100.0 if not self.cfg.box.build.randomDensity else 500.0
-        
-        for i in range(self.num_envs):
-            box_size = torch.tensor(self.cfg.box.build.baseSize) 
-            box_asset = self.gym.create_box(
-                self.sim, 
-                box_size[0], box_size[1], box_size[2],
-                asset_options
+        for env_id, env_ptr in enumerate(self.envs):
+            handle = self.gym.create_actor(
+                env_ptr,
+                box_asset,
+                default_pose,
+                "carry_box",
+                env_id,
+                0,
+                0,
             )
-            
-            start_pose = gymapi.Transform()
-            start_pose.p = gymapi.Vec3(0.5, 0.0, box_size[2]/2)
-            
-            box_handle = self.gym.create_actor(
-                self.envs[i], box_asset, start_pose,
-                "box", i, 0, 0
-            )
-            self.box_handles.append(box_handle)
-            
+            self.box_handles.append(handle)
+
     def _init_buffers(self):
         super()._init_buffers()
-        
-        # 箱子状态
-        self.box_states = self.all_root_states[:, 1]  # [num_envs, 13]
+
+        # 箱体状态（view），与 root-state tensor 共享存储。
+        self.box_states = self.get_extra_actor_state_view(0)
         self.box_pos = self.box_states[:, 0:3]
         self.box_rot = self.box_states[:, 3:7]
         self.box_vel = self.box_states[:, 7:10]
-        
-        # 目标位置
+
+        # 目标位置/缓存
         self.tar_pos = torch.zeros(self.num_envs, 3, device=self.device)
         self.prev_box_pos = torch.zeros_like(self.box_pos)
-        
-        # 手部关键点
-        self.hand_indices = [5, 11]  # 左右踝关节作为抓取点
-        
+
+        # "手" 的 proxy 索引（用脚部代替）
+        self.hand_indices = [5, 11]
+
+        # 初始化所有环境的箱子状态
+        env_ids = torch.arange(self.num_envs, device=self.device, dtype=torch.long)
+        self._reset_boxes(env_ids)
+
+    # ------------------------------------------------------------------
+    # 观测与奖励
+    # ------------------------------------------------------------------
     def compute_observations(self):
         super().compute_observations()
         if self.cfg.env.enableTaskObs:
             task_obs = self._compute_task_obs()
             self.obs_buf = torch.cat([self.obs_buf, task_obs], dim=-1)
-            
+            if self.privileged_obs_buf is not None:
+                self.privileged_obs_buf = torch.cat([self.privileged_obs_buf, task_obs], dim=-1)
+
     def _compute_task_obs(self):
-        """计算任务观测"""
-        # 相对位置和速度
         rel_box_pos = self.box_pos - self.base_pos
         rel_tar_pos = self.tar_pos - self.base_pos
-        
-        # 箱子朝向
+
         box_rot_obs = torch.cat([
-            self.box_rot[:, -1:],  # w
-            self.box_rot[:, :3]    # x,y,z
+            self.box_rot[:, -1:].contiguous(),  # w
+            self.box_rot[:, :3].contiguous(),
         ], dim=-1)
-        
+
         return torch.cat([
             rel_tar_pos,
             rel_box_pos,
             box_rot_obs,
             self.box_vel,
         ], dim=-1)
-        
+
     def _reward_carry_walk(self):
-        """靠近箱子的奖励"""
         dist = torch.norm(self.box_pos[:, :2] - self.base_pos[:, :2], dim=-1)
         return torch.exp(-0.5 * dist)
-        
+
     def _reward_carry_vel(self):
-        """搬运速度奖励"""
         box_to_tar = self.tar_pos[:, :2] - self.box_pos[:, :2]
-        box_to_tar_dir = box_to_tar / (torch.norm(box_to_tar, dim=-1, keepdim=True) + 1e-6)
-        box_vel_2d = self.box_vel[:, :2]
-        vel_reward = torch.sum(box_to_tar_dir * box_vel_2d, dim=-1)
-        return torch.exp(-2.0 * (1.5 - vel_reward)**2)
-        
+        norm = torch.norm(box_to_tar, dim=-1, keepdim=True)
+        box_to_tar_dir = box_to_tar / (norm + 1e-6)
+        vel_reward = torch.sum(box_to_tar_dir * self.box_vel[:, :2], dim=-1)
+        return torch.exp(-2.0 * (1.5 - vel_reward) ** 2)
+
     def _reward_handheld(self):
-        """抓取奖励"""
-        hand_pos = self.feet_pos[:, :2]  # 使用脚部位置模拟手
+        hand_pos = self.feet_pos[:, :, :2]
         hand_to_box = torch.norm(hand_pos.mean(dim=1) - self.box_pos[:, :2], dim=-1)
         return torch.exp(-5.0 * hand_to_box)
-        
+
     def _reward_putdown(self):
-        """放置奖励"""
         at_target = torch.norm(self.box_pos - self.tar_pos, dim=-1) < 0.1
-        on_ground = torch.abs(self.box_pos[:, 2] - self.cfg.box.build.baseSize[2]/2) < 0.01
+        on_ground = torch.abs(self.box_pos[:, 2] - self.cfg.box.build.baseSize[2] / 2.0) < 0.02
         return (at_target & on_ground).float()
-        
+
+    # ------------------------------------------------------------------
+    # 状态更新与重置
+    # ------------------------------------------------------------------
     def reset_idx(self, env_ids):
         super().reset_idx(env_ids)
-        if len(env_ids) > 0:
-            # 重置箱子位置
-            self.box_states[env_ids, 0:2] = torch_rand_float(-0.5, 0.5, (len(env_ids), 2), device=self.device)
-            self.box_states[env_ids, 2] = self.cfg.box.build.baseSize[2]/2
-            self.box_states[env_ids, 3:7] = torch.tensor([0, 0, 0, 1], device=self.device)
-            self.box_states[env_ids, 7:] = 0
-            
-            # 重置目标位置
-            self.tar_pos[env_ids, 0:2] = torch_rand_float(-2, 2, (len(env_ids), 2), device=self.device)
-            self.tar_pos[env_ids, 2] = self.cfg.box.build.baseSize[2]/2
+        if len(env_ids) == 0:
+            return
+        if not torch.is_tensor(env_ids):
+            env_ids = torch.as_tensor(env_ids, device=self.device, dtype=torch.long)
+        else:
+            env_ids = env_ids.to(self.device, dtype=torch.long)
+        self._reset_boxes(env_ids)
+
+    def _reset_boxes(self, env_ids: torch.Tensor):
+        if env_ids.numel() == 0:
+            return
+
+        height = float(self.cfg.box.build.baseSize[2])
+
+        # 随机起始位置/姿态
+        self.box_states[env_ids, 0:2] = torch_rand_float(-0.6, 0.6, (env_ids.numel(), 2), device=self.device)
+        self.box_states[env_ids, 2] = height / 2.0
+        self.box_states[env_ids, 3:7] = torch.tensor([0.0, 0.0, 0.0, 1.0], device=self.device)
+        self.box_states[env_ids, 7:13] = 0.0
+
+        # 随机目标位置
+        self.tar_pos[env_ids, 0:2] = torch_rand_float(-2.0, 2.0, (env_ids.numel(), 2), device=self.device)
+        self.tar_pos[env_ids, 2] = height / 2.0
+
+        self.prev_box_pos[env_ids] = self.box_pos[env_ids]
+
+        # 写回仿真
+        self.set_extra_actor_states(0, env_ids)
+
+    def _post_physics_step_callback(self):
+        super()._post_physics_step_callback()
+        self.prev_box_pos[:] = self.box_pos

--- a/legged_gym/envs/g1/g1_climb_env.py
+++ b/legged_gym/envs/g1/g1_climb_env.py
@@ -1,311 +1,273 @@
 import torch
-import numpy as np
-from isaacgym import gymapi, gymtorch
+from isaacgym import gymapi
 from isaacgym.torch_utils import *
+
+from phc.phc.utils import torch_utils
+
 from legged_gym.envs.g1.g1_env import G1Robot
-from legged_gym import LEGGED_GYM_ROOT_DIR
-import os
+
 
 class G1ClimbRobot(G1Robot):
-    """G1攀爬任务环境"""
-    
+    """Unitree G1 攀爬交互任务。"""
+
     def __init__(self, cfg, sim_params, physics_engine, sim_device, headless):
-        # 攀爬任务需要2个actors: robot + climb_object
-        self.actors_per_env = 2
+        # 额外的攀爬物体 actor
+        self.extra_actors_per_env = 1
+        self._env_climb_bbox = []
         super().__init__(cfg, sim_params, physics_engine, sim_device, headless)
-        
+
+        self._climb_actor_rows = self.get_extra_actor_row_indices(0)
+
+    # ------------------------------------------------------------------
+    # 资产与环境创建
+    # ------------------------------------------------------------------
     def _create_envs(self):
-        """创建环境，包含机器人和攀爬物体"""
-        # 先创建攀爬物体资产
         self._create_climb_assets()
         super()._create_envs()
-        
+
     def _create_climb_assets(self):
-        """创建攀爬物体资产"""
         self.climb_assets = []
-        asset_options = gymapi.AssetOptions()
-        asset_options.fix_base_link = True
-        asset_options.density = 1000.0
-        asset_options.angular_damping = 0.01
-        asset_options.linear_damping = 0.01
-        
-        # 创建不同类型的攀爬物体
+        self.climb_asset_bbox = []
+
+        asset_opts = gymapi.AssetOptions()
+        asset_opts.fix_base_link = True
+        asset_opts.density = 1000.0
+        asset_opts.angular_damping = 0.01
+        asset_opts.linear_damping = 0.01
+
         for cat in self.cfg.env.objCategories:
             if cat == "stairs":
-                # 创建楼梯
-                asset = self._create_stairs_asset(asset_options)
+                width, depth, height, num_steps = 1.5, 0.3, 0.15, 4
+                asset = self.gym.create_box(
+                    self.sim,
+                    width,
+                    depth * num_steps,
+                    height * num_steps,
+                    asset_opts,
+                )
+                bbox = (width, depth * num_steps, height * num_steps)
             elif cat == "ramp":
-                # 创建斜坡
-                asset = self._create_ramp_asset(asset_options)
+                ramp_width, ramp_length, ramp_height = 1.5, 2.0, 0.5
+                asset = self.gym.create_box(
+                    self.sim,
+                    ramp_width,
+                    ramp_length,
+                    ramp_height,
+                    asset_opts,
+                )
+                bbox = (ramp_width, ramp_length, ramp_height)
             elif cat == "obstacle":
-                # 创建障碍物
-                asset = self._create_obstacle_asset(asset_options)
+                asset = self.gym.create_box(self.sim, 1.0, 1.0, 0.4, asset_opts)
+                bbox = (1.0, 1.0, 0.4)
             else:
-                # 默认创建一个箱子
-                asset = self.gym.create_box(self.sim, 1.0, 0.5, 0.3, asset_options)
+                asset = self.gym.create_box(self.sim, 1.0, 0.5, 0.5, asset_opts)
+                bbox = (1.0, 0.5, 0.5)
+
             self.climb_assets.append(asset)
-            
-    def _create_stairs_asset(self, options):
-        """创建楼梯资产"""
-        # 简化版：用多个箱子组成楼梯
-        stair_width = 1.5
-        stair_depth = 0.3
-        stair_height = 0.15
-        num_steps = 4
-        
-        # 这里简化处理，实际应该组合多个箱子
-        return self.gym.create_box(self.sim, stair_width, stair_depth * num_steps, stair_height * num_steps, options)
-        
-    def _create_ramp_asset(self, options):
-        """创建斜坡资产"""
-        ramp_length = 2.0
-        ramp_width = 1.5
-        ramp_height = 0.5
-        return self.gym.create_box(self.sim, ramp_width, ramp_length, ramp_height, options)
-        
-    def _create_obstacle_asset(self, options):
-        """创建障碍物资产"""
-        return self.gym.create_box(self.sim, 1.0, 1.0, 0.4, options)
-        
+            self.climb_asset_bbox.append(torch.tensor(bbox, dtype=torch.float32))
+
     def _build_env(self, env_id, env_ptr, robot_asset):
-        """构建单个环境"""
         super()._build_env(env_id, env_ptr, robot_asset)
-        
-        # 添加攀爬物体
-        climb_asset_id = env_id % len(self.climb_assets)
-        climb_asset = self.climb_assets[climb_asset_id]
-        
+
+        asset_id = env_id % len(self.climb_assets)
+        climb_asset = self.climb_assets[asset_id]
+        bbox = self.climb_asset_bbox[asset_id]
+
         climb_pose = gymapi.Transform()
-        climb_pose.p = gymapi.Vec3(2.0, 0.0, 0.0)  # 放在机器人前方
+        climb_pose.p = gymapi.Vec3(2.0, 0.0, 0.0)
         climb_pose.r = gymapi.Quat(0.0, 0.0, 0.0, 1.0)
-        
-        climb_handle = self.gym.create_actor(
-            env_ptr, climb_asset, climb_pose,
-            f"climb_object_{env_id}", env_id, 0, 0
+
+        self.gym.create_actor(
+            env_ptr,
+            climb_asset,
+            climb_pose,
+            f"climb_object_{env_id}",
+            env_id,
+            0,
+            0,
         )
-        
-        # 设置颜色
-        self.gym.set_rigid_body_color(
-            env_ptr, climb_handle, 0, 
-            gymapi.MESH_VISUAL,
-            gymapi.Vec3(0.5, 0.5, 0.5)
-        )
-        
+
+        self._env_climb_bbox.append(bbox)
+
+    # ------------------------------------------------------------------
+    # 缓冲区与观测
+    # ------------------------------------------------------------------
     def _init_buffers(self):
-        """初始化缓冲区"""
         super()._init_buffers()
-        
-        # 攀爬物体状态
-        self.climb_object_states = self.all_root_states[:, 1]  # [num_envs, 13]
+
+        self.climb_object_states = self.get_extra_actor_state_view(0)
         self.climb_object_pos = self.climb_object_states[:, 0:3]
         self.climb_object_rot = self.climb_object_states[:, 3:7]
-        
-        # 目标攀爬位置（物体顶部）
+
+        self.climb_object_bbox = torch.stack(
+            [bbox.to(self.device) for bbox in self._env_climb_bbox], dim=0
+        )
+
         self.climb_target_pos = torch.zeros(self.num_envs, 3, device=self.device)
-        self.climb_target_pos[:, 2] = 0.5  # 默认高度
-        
-        # 攀爬进度跟踪
         self.climb_progress = torch.zeros(self.num_envs, device=self.device)
         self.prev_climb_height = torch.zeros(self.num_envs, device=self.device)
-        
-        # IET（交互早期终止）相关
+
         if self.cfg.env.enableIET:
             self.IET_step_buf = torch.zeros(self.num_envs, device=self.device, dtype=torch.long)
             self.IET_triggered = torch.zeros(self.num_envs, device=self.device, dtype=torch.bool)
-            
-        # 物体边界框（简化版）
-        self.object_bbox_size = torch.tensor([1.5, 2.0, 0.5], device=self.device)  # 宽x深x高
-        
+
+        env_ids = torch.arange(self.num_envs, device=self.device, dtype=torch.long)
+        self._reset_climb_objects(env_ids)
+
     def compute_observations(self):
-        """计算观测"""
         super().compute_observations()
-        
         if self.cfg.env.enableTaskObs:
             task_obs = self._compute_task_obs()
             self.obs_buf = torch.cat([self.obs_buf, task_obs], dim=-1)
             if self.privileged_obs_buf is not None:
                 self.privileged_obs_buf = torch.cat([self.privileged_obs_buf, task_obs], dim=-1)
-                
+
     def _compute_task_obs(self):
-        """计算任务相关观测"""
-        # 计算相对位置
         rel_object_pos = self.climb_object_pos - self.base_pos
         rel_target_pos = self.climb_target_pos - self.base_pos
-        
-        # 将相对位置转换到机器人局部坐标系
+
         heading_rot = torch_utils.calc_heading_quat_inv(self.base_quat)
         local_object_pos = quat_rotate(heading_rot, rel_object_pos)
         local_target_pos = quat_rotate(heading_rot, rel_target_pos)
-        
-        # 物体朝向（简化为四元数的一部分）
-        object_rot_obs = self.climb_object_rot
-        
-        # 计算物体8个角点的位置（边界框）
+
         bbox_points = self._compute_bbox_points()
         local_bbox_points = self._transform_bbox_to_local(bbox_points, heading_rot)
-        
-        # 组合观测
+
         task_obs = torch.cat([
-            local_target_pos,                           # 3
-            local_object_pos,                           # 3
-            object_rot_obs,                             # 4
-            local_bbox_points.reshape(self.num_envs, -1)[:, :24]  # 24 (8个点的前8个坐标)
+            local_target_pos,
+            local_object_pos,
+            self.climb_object_rot,
+            local_bbox_points.reshape(self.num_envs, -1)[:, :24],
         ], dim=-1)
-        
         return task_obs
-        
+
     def _compute_bbox_points(self):
-        """计算物体边界框的8个角点"""
-        half_size = self.object_bbox_size / 2
-        
-        # 8个角点的局部坐标
-        corners = torch.tensor([
-            [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],  # 底部4个点
-            [-1, -1, 1], [1, -1, 1], [1, 1, 1], [-1, 1, 1]        # 顶部4个点
-        ], device=self.device) * half_size.unsqueeze(0)
-        
-        # 转换到世界坐标
-        corners_expanded = corners.unsqueeze(0).expand(self.num_envs, -1, -1)
-        object_rot_expanded = self.climb_object_rot.unsqueeze(1).expand(-1, 8, -1)
-        world_corners = quat_rotate(object_rot_expanded.reshape(-1, 4), corners_expanded.reshape(-1, 3))
+        half_size = self.climb_object_bbox / 2.0
+        corners = torch.tensor(
+            [
+                [-1, -1, -1],
+                [1, -1, -1],
+                [1, 1, -1],
+                [-1, 1, -1],
+                [-1, -1, 1],
+                [1, -1, 1],
+                [1, 1, 1],
+                [-1, 1, 1],
+            ],
+            device=self.device,
+            dtype=torch.float32,
+        )
+        corners = corners.unsqueeze(0) * half_size.unsqueeze(1)
+
+        rot = self.climb_object_rot.unsqueeze(1).expand(-1, 8, -1)
+        world_corners = quat_rotate(rot.reshape(-1, 4), corners.reshape(-1, 3))
         world_corners = world_corners.reshape(self.num_envs, 8, 3)
         world_corners += self.climb_object_pos.unsqueeze(1)
-        
         return world_corners
-        
+
     def _transform_bbox_to_local(self, bbox_points, heading_rot):
-        """将边界框点转换到机器人局部坐标系"""
         rel_points = bbox_points - self.base_pos.unsqueeze(1)
-        heading_rot_expanded = heading_rot.unsqueeze(1).expand(-1, 8, -1)
+        heading_exp = heading_rot.unsqueeze(1).expand(-1, bbox_points.shape[1], -1)
         local_points = quat_rotate(
-            heading_rot_expanded.reshape(-1, 4),
-            rel_points.reshape(-1, 3)
+            heading_exp.reshape(-1, 4),
+            rel_points.reshape(-1, 3),
         )
-        return local_points.reshape(self.num_envs, 8, 3)
-        
+        return local_points.reshape(self.num_envs, -1, 3)
+
+    # ------------------------------------------------------------------
+    # 状态更新/重置
+    # ------------------------------------------------------------------
+    def reset_idx(self, env_ids):
+        super().reset_idx(env_ids)
+        if len(env_ids) == 0:
+            return
+        if not torch.is_tensor(env_ids):
+            env_ids = torch.as_tensor(env_ids, device=self.device, dtype=torch.long)
+        else:
+            env_ids = env_ids.to(self.device, dtype=torch.long)
+        self._reset_climb_objects(env_ids)
+
+    def _reset_climb_objects(self, env_ids: torch.Tensor):
+        if env_ids.numel() == 0:
+            return
+
+        self.climb_object_states[env_ids, 0] = torch_rand_float(1.5, 3.0, (env_ids.numel(),), device=self.device)
+        self.climb_object_states[env_ids, 1] = torch_rand_float(-0.5, 0.5, (env_ids.numel(),), device=self.device)
+        self.climb_object_states[env_ids, 2] = 0.0
+        self.climb_object_states[env_ids, 3:7] = torch.tensor([0.0, 0.0, 0.0, 1.0], device=self.device)
+        self.climb_object_states[env_ids, 7:13] = 0.0
+
+        bbox = self.climb_object_bbox[env_ids]
+        self.climb_target_pos[env_ids, 0:2] = self.climb_object_states[env_ids, 0:2]
+        self.climb_target_pos[env_ids, 2] = bbox[:, 2] + self.cfg.rewards.base_height_target
+
+        self.climb_progress[env_ids] = 0.0
+        self.prev_climb_height[env_ids] = self.base_pos[env_ids, 2]
+
+        if self.cfg.env.enableIET:
+            self.IET_step_buf[env_ids] = 0
+            self.IET_triggered[env_ids] = False
+
+        self.set_extra_actor_states(0, env_ids)
+
     def _post_physics_step_callback(self):
-        """物理步后回调"""
         super()._post_physics_step_callback()
-        
-        # 更新攀爬进度
-        self.climb_progress = (self.base_pos[:, 2] - self.cfg.rewards.base_height_target) / self.object_bbox_size[2]
-        self.climb_progress = torch.clamp(self.climb_progress, 0, 1)
-        
-        # 检查IET条件
+
+        denom = torch.clamp(self.climb_object_bbox[:, 2], min=0.2)
+        self.climb_progress = (self.base_pos[:, 2] - self.cfg.rewards.base_height_target) / denom
+        self.climb_progress = torch.clamp(self.climb_progress, 0.0, 1.0)
+
         if self.cfg.env.enableIET:
             self._check_iet_condition()
-            
+
     def _check_iet_condition(self):
-        """检查交互早期终止条件"""
-        # 检查是否到达目标位置
         dist_to_target = torch.norm(self.base_pos - self.climb_target_pos, dim=-1)
         success_mask = dist_to_target < self.cfg.env.successThreshold
-        
-        # 更新IET计数器
         self.IET_step_buf[success_mask] += 1
         self.IET_step_buf[~success_mask] = 0
-        
-        # 触发IET
         self.IET_triggered = self.IET_step_buf >= self.cfg.env.maxIETSteps
-        
+
     def check_termination(self):
-        """检查终止条件"""
         super().check_termination()
-        
-        # 添加IET终止
         if self.cfg.env.enableIET:
             self.reset_buf |= self.IET_triggered
-            
-        # 添加掉落检测
         fell_off = self.base_pos[:, 2] < (self.cfg.rewards.base_height_target - 0.3)
         self.reset_buf |= fell_off
-        
+
+    # ------------------------------------------------------------------
+    # 奖励函数
+    # ------------------------------------------------------------------
     def _reward_climb_progress(self):
-        """攀爬进度奖励"""
         height_progress = self.base_pos[:, 2] - self.prev_climb_height
         self.prev_climb_height[:] = self.base_pos[:, 2]
-        return torch.clamp(height_progress * 10, -1, 1)
-        
+        return torch.clamp(height_progress * 10.0, -1.0, 1.0)
+
     def _reward_feet_clearance(self):
-        """脚部离地高度奖励（攀爬时需要抬高脚）"""
-        # 在摆动相时奖励脚部抬高
         feet_height = self.feet_pos[:, :, 2] - self.climb_object_pos[:, 2].unsqueeze(1)
-        
-        # 使用相位信息
         swing_mask = self.leg_phase > 0.5
-        clearance_reward = feet_height * swing_mask
-        
-        return torch.sum(clearance_reward, dim=1) * 0.1
-        
+        clearance = feet_height * swing_mask
+        return torch.sum(clearance, dim=1) * 0.1
+
     def _reward_climb_stability(self):
-        """攀爬稳定性奖励"""
-        # 惩罚过大的身体倾斜
         gravity_penalty = torch.sum(torch.square(self.projected_gravity[:, :2]), dim=1)
-        
-        # 惩罚过大的角速度
         ang_vel_penalty = torch.sum(torch.square(self.base_ang_vel), dim=1)
-        
         return -gravity_penalty - 0.1 * ang_vel_penalty
-        
+
     def _reward_approach_object(self):
-        """接近物体奖励"""
-        dist_to_object = torch.norm(
-            self.climb_object_pos[:, :2] - self.base_pos[:, :2], 
-            dim=-1
-        )
-        approach_reward = torch.exp(-dist_to_object)
-        
-        # 只在未开始攀爬时给予此奖励
-        not_climbing = self.climb_progress < 0.1
-        return approach_reward * not_climbing
-        
+        dist = torch.norm(self.climb_object_pos[:, :2] - self.base_pos[:, :2], dim=-1)
+        reward = torch.exp(-dist)
+        return reward * (self.climb_progress < 0.1)
+
     def _reward_feet_contact_on_object(self):
-        """脚部接触物体奖励"""
-        # 检查脚部是否在物体上方
-        feet_above_object = self.feet_pos[:, :, 2] > self.climb_object_pos[:, 2].unsqueeze(1)
-        
-        # 检查脚部是否在物体范围内（简化检查）
-        feet_in_range_x = torch.abs(
+        half_size = self.climb_object_bbox / 2.0
+        feet_above = self.feet_pos[:, :, 2] > self.climb_object_pos[:, 2].unsqueeze(1)
+        feet_in_x = torch.abs(
             self.feet_pos[:, :, 0] - self.climb_object_pos[:, 0].unsqueeze(1)
-        ) < self.object_bbox_size[0]/2
-        
-        feet_in_range_y = torch.abs(
+        ) < half_size[:, 0].unsqueeze(1)
+        feet_in_y = torch.abs(
             self.feet_pos[:, :, 1] - self.climb_object_pos[:, 1].unsqueeze(1)
-        ) < self.object_bbox_size[1]/2
-        
-        feet_on_object = feet_above_object & feet_in_range_x & feet_in_range_y
-        
-        # 结合接触力信息
+        ) < half_size[:, 1].unsqueeze(1)
+        feet_on = feet_above & feet_in_x & feet_in_y
         feet_contact = torch.norm(self.contact_forces[:, self.feet_indices], dim=-1) > 1.0
-        
-        valid_contact = feet_on_object & feet_contact
-        
+        valid_contact = feet_on & feet_contact
         return torch.sum(valid_contact.float(), dim=1) * 0.5
-        
-    def reset_idx(self, env_ids):
-        """重置环境"""
-        super().reset_idx(env_ids)
-        
-        if len(env_ids) > 0:
-            # 重置攀爬物体位置（随机放置在前方）
-            self.climb_object_states[env_ids, 0] = torch_rand_float(
-                1.5, 3.0, (len(env_ids),), device=self.device
-            )
-            self.climb_object_states[env_ids, 1] = torch_rand_float(
-                -0.5, 0.5, (len(env_ids),), device=self.device
-            )
-            self.climb_object_states[env_ids, 2] = 0  # 地面上
-            
-            # 重置目标位置（物体顶部）
-            self.climb_target_pos[env_ids, 0] = self.climb_object_states[env_ids, 0]
-            self.climb_target_pos[env_ids, 1] = self.climb_object_states[env_ids, 1]
-            self.climb_target_pos[env_ids, 2] = self.object_bbox_size[2] + self.cfg.rewards.base_height_target
-            
-            # 重置进度
-            self.climb_progress[env_ids] = 0
-            self.prev_climb_height[env_ids] = self.base_pos[env_ids, 2]
-            
-            # 重置IET
-            if self.cfg.env.enableIET:
-                self.IET_step_buf[env_ids] = 0
-                self.IET_triggered[env_ids] = False

--- a/legged_gym/envs/g1/g1_sit_env.py
+++ b/legged_gym/envs/g1/g1_sit_env.py
@@ -1,297 +1,283 @@
 import torch
-import numpy as np
-from isaacgym import gymapi, gymtorch
+from isaacgym import gymapi
 from isaacgym.torch_utils import *
+
+from phc.phc.utils import torch_utils
+
 from legged_gym.envs.g1.g1_env import G1Robot
-from legged_gym import LEGGED_GYM_ROOT_DIR
-import os
-import json
+
 
 class G1SitRobot(G1Robot):
-    """G1坐下任务环境"""
-    
+    """Unitree G1 坐下交互任务。"""
+
     def __init__(self, cfg, sim_params, physics_engine, sim_device, headless):
-        # 坐下任务需要2个actors: robot + seat_object
-        self.actors_per_env = 2
+        self.extra_actors_per_env = 1
+        self._env_seat_configs = []
         super().__init__(cfg, sim_params, physics_engine, sim_device, headless)
-        
+
+        self._seat_actor_rows = self.get_extra_actor_row_indices(0)
+
+    # ------------------------------------------------------------------
+    # 资产与环境构建
+    # ------------------------------------------------------------------
     def _create_envs(self):
-        """创建环境，包含机器人和座椅"""
         self._load_seat_assets()
         super()._create_envs()
-        
+
     def _load_seat_assets(self):
-        """加载座椅资产"""
         self.seat_assets = []
         self.seat_configs = []
-        
-        asset_options = gymapi.AssetOptions()
-        asset_options.fix_base_link = True
-        asset_options.density = 1000.0
-        asset_options.angular_damping = 0.01
-        asset_options.linear_damping = 0.01
-        
-        # 为每种类别创建资产
+
+        asset_opts = gymapi.AssetOptions()
+        asset_opts.fix_base_link = True
+        asset_opts.density = 1000.0
+        asset_opts.angular_damping = 0.01
+        asset_opts.linear_damping = 0.01
+
         for cat in self.cfg.env.objCategories:
             if cat == "chair":
-                asset, config = self._create_chair_asset(asset_options)
+                asset, cfg = self._create_chair_asset(asset_opts)
             elif cat == "stool":
-                asset, config = self._create_stool_asset(asset_options)
+                asset, cfg = self._create_stool_asset(asset_opts)
             elif cat == "bench":
-                asset, config = self._create_bench_asset(asset_options)
+                asset, cfg = self._create_bench_asset(asset_opts)
             else:
-                asset, config = self._create_default_seat_asset(asset_options)
-                
+                asset, cfg = self._create_default_seat_asset(asset_opts)
+
             self.seat_assets.append(asset)
-            self.seat_configs.append(config)
-            
+            self.seat_configs.append(cfg)
+
     def _create_chair_asset(self, options):
-        """创建椅子资产"""
-        # 简化版椅子：座位 + 靠背
-        seat_width = 0.5
-        seat_depth = 0.5
-        seat_height = 0.45
-        
-        asset = self.gym.create_box(
-            self.sim, seat_width, seat_depth, seat_height, options
-        )
-        
-        config = {
+        seat_width, seat_depth, seat_height = 0.5, 0.5, 0.45
+        asset = self.gym.create_box(self.sim, seat_width, seat_depth, seat_height, options)
+        cfg = {
             "seat_height": seat_height,
-            "seat_center": [0, 0, seat_height/2],
             "bbox": [seat_width, seat_depth, seat_height],
-            "facing": [1, 0, 0],  # 朝向前方
-            "sit_offset": [0, 0, seat_height + 0.1]  # 坐的目标位置
+            "facing": [1.0, 0.0, 0.0],
+            "sit_offset": [0.0, 0.0, seat_height + 0.1],
         }
-        
-        return asset, config
-        
+        return asset, cfg
+
     def _create_stool_asset(self, options):
-        """创建凳子资产"""
-        stool_radius = 0.3
-        stool_height = 0.4
-        
-        # 用箱子简化表示圆凳
-        asset = self.gym.create_box(
-            self.sim, stool_radius*2, stool_radius*2, stool_height, options
-        )
-        
-        config = {
-            "seat_height": stool_height,
-            "seat_center": [0, 0, stool_height/2],
-            "bbox": [stool_radius*2, stool_radius*2, stool_height],
-            "facing": [1, 0, 0],
-            "sit_offset": [0, 0, stool_height + 0.1]
+        radius, height = 0.3, 0.4
+        asset = self.gym.create_box(self.sim, radius * 2, radius * 2, height, options)
+        cfg = {
+            "seat_height": height,
+            "bbox": [radius * 2, radius * 2, height],
+            "facing": [1.0, 0.0, 0.0],
+            "sit_offset": [0.0, 0.0, height + 0.1],
         }
-        
-        return asset, config
-        
+        return asset, cfg
+
     def _create_bench_asset(self, options):
-        """创建长凳资产"""
-        bench_width = 1.2
-        bench_depth = 0.4
-        bench_height = 0.42
-        
-        asset = self.gym.create_box(
-            self.sim, bench_width, bench_depth, bench_height, options
-        )
-        
-        config = {
-            "seat_height": bench_height,
-            "seat_center": [0, 0, bench_height/2],
-            "bbox": [bench_width, bench_depth, bench_height],
-            "facing": [1, 0, 0],
-            "sit_offset": [0, 0, bench_height + 0.1]
+        width, depth, height = 1.2, 0.4, 0.42
+        asset = self.gym.create_box(self.sim, width, depth, height, options)
+        cfg = {
+            "seat_height": height,
+            "bbox": [width, depth, height],
+            "facing": [1.0, 0.0, 0.0],
+            "sit_offset": [0.0, 0.0, height + 0.1],
         }
-        
-        return asset, config
-        
+        return asset, cfg
+
     def _create_default_seat_asset(self, options):
-        """创建默认座椅"""
         return self._create_chair_asset(options)
-        
+
     def _build_env(self, env_id, env_ptr, robot_asset):
-        """构建单个环境"""
         super()._build_env(env_id, env_ptr, robot_asset)
-        
-        # 选择座椅类型
-        seat_id = env_id % len(self.seat_assets)
-        seat_asset = self.seat_assets[seat_id]
-        seat_config = self.seat_configs[seat_id]
-        
-        # 放置座椅
+
+        seat_asset_id = env_id % len(self.seat_assets)
+        seat_asset = self.seat_assets[seat_asset_id]
+        seat_cfg = self.seat_configs[seat_asset_id]
+
         seat_pose = gymapi.Transform()
-        seat_pose.p = gymapi.Vec3(1.0, 0.0, 0.0)  # 前方1米
-        
-        # 随机旋转
-        if self.cfg.env.mode == "train":
-            yaw = np.random.uniform(-np.pi/4, np.pi/4)
-        else:
-            yaw = 0
-        seat_pose.r = gymapi.Quat.from_axis_angle(gymapi.Vec3(0, 0, 1), yaw)
-        
-        seat_handle = self.gym.create_actor(
-            env_ptr, seat_asset, seat_pose,
-            f"seat_{env_id}", env_id, 0, 0
+        seat_pose.p = gymapi.Vec3(1.0, 0.0, seat_cfg["bbox"][2] / 2.0)
+        seat_pose.r = gymapi.Quat(0.0, 0.0, 0.0, 1.0)
+
+        self.gym.create_actor(
+            env_ptr,
+            seat_asset,
+            seat_pose,
+            f"seat_{env_id}",
+            env_id,
+            0,
+            0,
         )
-        
-        # 设置颜色
-        self.gym.set_rigid_body_color(
-            env_ptr, seat_handle, 0,
-            gymapi.MESH_VISUAL,
-            gymapi.Vec3(0.6, 0.4, 0.2)  # 棕色
-        )
-        
-        # 保存配置
-        if not hasattr(self, 'env_seat_configs'):
-            self.env_seat_configs = []
-        self.env_seat_configs.append(seat_config)
-        
+
+        self._env_seat_configs.append(seat_cfg)
+
+    # ------------------------------------------------------------------
+    # 缓冲区与观测
+    # ------------------------------------------------------------------
     def _init_buffers(self):
-        """初始化缓冲区"""
         super()._init_buffers()
-        
-        # 座椅状态
-        self.seat_states = self.all_root_states[:, 1]  # [num_envs, 13]
+
+        self.seat_states = self.get_extra_actor_state_view(0)
         self.seat_pos = self.seat_states[:, 0:3]
         self.seat_rot = self.seat_states[:, 3:7]
-        
-        # 目标坐姿位置
+
+        configs = [
+            cfg if cfg is not None else self.seat_configs[0]
+            for cfg in self._env_seat_configs
+        ]
+        self.seat_heights = torch.tensor([cfg["seat_height"] for cfg in configs], device=self.device)
+        self.seat_bbox = torch.tensor([cfg["bbox"] for cfg in configs], device=self.device)
+        self.seat_facing = torch.tensor([cfg["facing"] for cfg in configs], device=self.device)
+        self.seat_sit_offset = torch.tensor([cfg["sit_offset"] for cfg in configs], device=self.device)
+
         self.sit_target_pos = torch.zeros(self.num_envs, 3, device=self.device)
         self.sit_target_orient = torch.zeros(self.num_envs, 4, device=self.device)
-        self.sit_target_orient[:, 3] = 1  # 单位四元数
-        
-        # 座椅配置转tensor
-        self._setup_seat_configs()
-        
-        # 坐下状态跟踪
-        self.is_sitting = torch.zeros(self.num_envs, device=self.device, dtype=torch.bool)
+        self.sit_state_buf = torch.zeros(self.num_envs, device=self.device)
         self.sit_stability_buf = torch.zeros(self.num_envs, device=self.device)
-        self.prev_base_vel = torch.zeros(self.num_envs, 6, device=self.device)
-        
-    def _setup_seat_configs(self):
-        """设置座椅配置张量"""
-        configs = self.env_seat_configs if hasattr(self, 'env_seat_configs') else [self.seat_configs[0]] * self.num_envs
-        
-        self.seat_heights = torch.tensor(
-            [c["seat_height"] for c in configs],
-            device=self.device
-        )
-        
-        self.seat_bbox = torch.tensor(
-            [c["bbox"] for c in configs],
-            device=self.device
-        )
-        
-        self.seat_facing = torch.tensor(
-            [c["facing"] for c in configs],
-            device=self.device
-        )
-        
-        self.seat_sit_offset = torch.tensor(
-            [c["sit_offset"] for c in configs],
-            device=self.device
-        )
-        
+
+        env_ids = torch.arange(self.num_envs, device=self.device, dtype=torch.long)
+        self._reset_seats(env_ids)
+
     def compute_observations(self):
-        """计算观测"""
         super().compute_observations()
-        
         if self.cfg.env.enableTaskObs:
             task_obs = self._compute_task_obs()
             self.obs_buf = torch.cat([self.obs_buf, task_obs], dim=-1)
             if self.privileged_obs_buf is not None:
                 self.privileged_obs_buf = torch.cat([self.privileged_obs_buf, task_obs], dim=-1)
-                
+
     def _compute_task_obs(self):
-        """计算任务观测"""
-        # 计算相对位置
         rel_seat_pos = self.seat_pos - self.base_pos
         rel_sit_target = self.sit_target_pos - self.base_pos
-        
-        # 转换到机器人局部坐标系
+
         heading_rot = torch_utils.calc_heading_quat_inv(self.base_quat)
         local_seat_pos = quat_rotate(heading_rot, rel_seat_pos)
         local_sit_target = quat_rotate(heading_rot, rel_sit_target)
-        
-        # 座椅朝向
+
         local_seat_rot = quat_mul(heading_rot, self.seat_rot)
         seat_rot_obs = torch_utils.quat_to_tan_norm(local_seat_rot)
-        
-        # 座椅朝向向量
+
         seat_facing_world = quat_rotate(self.seat_rot, self.seat_facing)
         local_seat_facing = quat_rotate(heading_rot, seat_facing_world)
-        
-        # 座椅边界框（8个角点）
+
         bbox_points = self._compute_seat_bbox_points()
         local_bbox = self._transform_to_local(bbox_points, heading_rot)
-        
-        # 坐姿稳定性指标
-        stability = self.sit_stability_buf.unsqueeze(-1)
-        
+
         task_obs = torch.cat([
-            local_sit_target,                              # 3
-            local_seat_pos,                                # 3
-            seat_rot_obs,                                  # 6
-            local_seat_facing[:, :2],                      # 2（只要水平朝向）
-            local_bbox.reshape(self.num_envs, -1)[:, :24], # 24
-            stability                                       # 1
+            local_sit_target,
+            local_seat_pos,
+            seat_rot_obs,
+            local_seat_facing[:, :2],
+            local_bbox.reshape(self.num_envs, -1)[:, :24],
+            self.sit_stability_buf.unsqueeze(-1),
         ], dim=-1)
-        
         return task_obs
-        
+
     def _compute_seat_bbox_points(self):
-        """计算座椅边界框8个角点"""
-        half_size = self.seat_bbox / 2
-        
-        corners = torch.tensor([
-            [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],
-            [-1, -1, 1], [1, -1, 1], [1, 1, 1], [-1, 1, 1]
-        ], device=self.device, dtype=torch.float)
-        
-        corners = corners.unsqueeze(0) * half_size.unsqueeze(1)
-        
-        # 旋转到世界坐标
-        seat_rot_expanded = self.seat_rot.unsqueeze(1).expand(-1, 8, -1)
-        world_corners = quat_rotate(
-            seat_rot_expanded.reshape(-1, 4),
-            corners.reshape(-1, 3)
+        half_size = self.seat_bbox / 2.0
+        corners = torch.tensor(
+            [
+                [-1, -1, -1],
+                [1, -1, -1],
+                [1, 1, -1],
+                [-1, 1, -1],
+                [-1, -1, 1],
+                [1, -1, 1],
+                [1, 1, 1],
+                [-1, 1, 1],
+            ],
+            device=self.device,
+            dtype=torch.float32,
         )
+        corners = corners.unsqueeze(0) * half_size.unsqueeze(1)
+        seat_rot = self.seat_rot.unsqueeze(1).expand(-1, 8, -1)
+        world_corners = quat_rotate(seat_rot.reshape(-1, 4), corners.reshape(-1, 3))
         world_corners = world_corners.reshape(self.num_envs, 8, 3)
         world_corners += self.seat_pos.unsqueeze(1)
-        
         return world_corners
-        
+
     def _transform_to_local(self, points, heading_rot):
-        """转换点到局部坐标系"""
         rel_points = points - self.base_pos.unsqueeze(1)
         heading_rot_expanded = heading_rot.unsqueeze(1).expand(-1, points.shape[1], -1)
         local_points = quat_rotate(
             heading_rot_expanded.reshape(-1, 4),
-            rel_points.reshape(-1, 3)
+            rel_points.reshape(-1, 3),
         )
         return local_points.reshape(self.num_envs, -1, 3)
-        
+
+    # ------------------------------------------------------------------
+    # 状态更新/重置
+    # ------------------------------------------------------------------
+    def reset_idx(self, env_ids):
+        super().reset_idx(env_ids)
+        if len(env_ids) == 0:
+            return
+        if not torch.is_tensor(env_ids):
+            env_ids = torch.as_tensor(env_ids, device=self.device, dtype=torch.long)
+        else:
+            env_ids = env_ids.to(self.device, dtype=torch.long)
+        self._reset_seats(env_ids)
+
+    def _reset_seats(self, env_ids: torch.Tensor):
+        if env_ids.numel() == 0:
+            return
+
+        seat_height = self.seat_heights[env_ids]
+
+        # 随机化座椅的位置和朝向
+        self.seat_states[env_ids, 0] = torch_rand_float(0.8, 1.5, (env_ids.numel(),), device=self.device)
+        self.seat_states[env_ids, 1] = torch_rand_float(-0.4, 0.4, (env_ids.numel(),), device=self.device)
+        self.seat_states[env_ids, 2] = seat_height / 2.0
+
+        yaw = torch_rand_float(-0.5, 0.5, (env_ids.numel(),), device=self.device)
+        quat = quat_from_euler_xyz(torch.zeros_like(yaw), torch.zeros_like(yaw), yaw)
+        self.seat_states[env_ids, 3:7] = quat
+        self.seat_states[env_ids, 7:13] = 0.0
+
+        # 目标位置/朝向
+        seat_rot = self.seat_rot[env_ids]
+        sit_offset = quat_rotate(seat_rot, self.seat_sit_offset[env_ids])
+        self.sit_target_pos[env_ids] = self.seat_pos[env_ids] + sit_offset
+        self.sit_target_orient[env_ids] = seat_rot
+
+        self.sit_state_buf[env_ids] = 0.0
+        self.sit_stability_buf[env_ids] = 0.0
+
+        self.set_extra_actor_states(0, env_ids)
+
     def _post_physics_step_callback(self):
-        """物理步后处理"""
         super()._post_physics_step_callback()
-        
-        # 更新目标坐姿位置
         self._update_sit_targets()
-        
-        # 检查坐姿状态
         self._check_sitting_state()
-        
-        # 更新稳定性
         self._update_stability()
-        
+
     def _update_sit_targets(self):
-        """更新目标坐姿位置"""
-        # 目标位置 = 座椅位置 + 坐姿偏移
-        seat_rot_expanded = self.seat_rot
-        sit_offset_world = quat_rotate(seat_rot_expanded, self.seat_sit_offset)
+        sit_offset_world = quat_rotate(self.seat_rot, self.seat_sit_offset)
         self.sit_target_pos = self.seat_pos + sit_offset_world
-        
-        # 目标朝向应该与座椅朝向一致
         self.sit_target_orient = self.seat_rot
-        
+
+    def _check_sitting_state(self):
+        pos_err = torch.norm(self.base_pos - self.sit_target_pos, dim=-1)
+        height_err = torch.abs(self.base_pos[:, 2] - self.sit_target_pos[:, 2])
+        vel_norm = torch.norm(self.base_lin_vel[:, :2], dim=-1)
+
+        sitting = (pos_err < 0.35) & (height_err < 0.2) & (vel_norm < 0.5)
+        self.sit_state_buf = sitting.float()
+
+    def _update_stability(self):
+        vel_norm = torch.norm(self.base_lin_vel, dim=-1)
+        ang_vel_norm = torch.norm(self.base_ang_vel, dim=-1)
+        stability_score = torch.exp(-vel_norm) * torch.exp(-0.5 * ang_vel_norm)
+        # 指数平均，增强平滑性
+        self.sit_stability_buf = 0.9 * self.sit_stability_buf + 0.1 * stability_score
+
+    # ------------------------------------------------------------------
+    # 奖励函数
+    # ------------------------------------------------------------------
+    def _reward_sit_position(self):
+        pos_err = torch.norm(self.base_pos - self.sit_target_pos, dim=-1)
+        return torch.exp(-3.0 * pos_err)
+
+    def _reward_sit_orientation(self):
+        heading = torch_utils.calc_heading_quat(self.base_quat)
+        seat_heading = torch_utils.calc_heading_quat(self.sit_target_orient)
+        diff = torch.abs(torch_utils.wrap_to_pi(heading - seat_heading))
+        return torch.exp(-2.0 * diff)
+
+    def _reward_stable_sitting(self):
+        return self.sit_stability_buf * self.sit_state_buf

--- a/legged_gym/envs/g1/g1_traj_env.py
+++ b/legged_gym/envs/g1/g1_traj_env.py
@@ -1,50 +1,128 @@
+import math
+
 import torch
-import numpy as np
+from isaacgym.torch_utils import torch_rand_float
+
+from phc.phc.utils import torch_utils
+
 from legged_gym.envs.g1.g1_env import G1Robot
 
+
 class G1TrajRobot(G1Robot):
-    
+
     def __init__(self, cfg, sim_params, physics_engine, sim_device, headless):
         super().__init__(cfg, sim_params, physics_engine, sim_device, headless)
-        self._init_trajectory()
-        
-    def _init_trajectory(self):
-        """初始化轨迹生成器"""
+        self._init_trajectory_buffers()
+
+    # ------------------------------------------------------------------
+    # 轨迹生成
+    # ------------------------------------------------------------------
+    def _init_trajectory_buffers(self):
         self.traj_points = torch.zeros(
-            self.num_envs, 
-            self.cfg.traj.num_samples, 
-            3,  # x,y,z
-            device=self.device
+            self.num_envs,
+            self.cfg.traj.num_samples,
+            3,
+            device=self.device,
         )
-        self._generate_trajectories()
-        
-    def _generate_trajectories(self):
-        """生成随机轨迹"""
-        for i in range(self.num_envs):
-            # 简单的圆形轨迹示例
-            t = torch.linspace(0, 2*np.pi, self.cfg.traj.num_samples, device=self.device)
-            radius = torch_rand_float(1.0, 3.0, (1,), device=self.device)
-            self.traj_points[i, :, 0] = radius * torch.cos(t) + self.base_pos[i, 0]
-            self.traj_points[i, :, 1] = radius * torch.sin(t) + self.base_pos[i, 1]
-            self.traj_points[i, :, 2] = self.cfg.rewards.base_height_target
-            
+        self.traj_dirs = torch.zeros(
+            self.num_envs,
+            self.cfg.traj.num_samples,
+            2,
+            device=self.device,
+        )
+        env_ids = torch.arange(self.num_envs, device=self.device, dtype=torch.long)
+        self._generate_trajectories(env_ids)
+
+    def _generate_trajectories(self, env_ids):
+        if env_ids.numel() == 0:
+            return
+
+        dt = self.cfg.traj.sample_timestep
+        speed_min = self.cfg.traj.speed_min
+        speed_max = self.cfg.traj.speed_max
+        accel_max = self.cfg.traj.accel_max
+        sharp_turn_prob = self.cfg.traj.sharp_turn_prob
+        sharp_turn_angle = self.cfg.traj.sharp_turn_angle
+
+        for env_id in env_ids.tolist():
+            start_pos = self.base_pos[env_id, :2]
+            points = self.traj_points[env_id]
+            dirs = self.traj_dirs[env_id]
+
+            heading = torch_rand_float(-math.pi, math.pi, (1,), device=self.device)[0]
+            speed = torch_rand_float(speed_min, speed_max, (1,), device=self.device)[0]
+
+            points[0, 0:2] = start_pos
+            points[0, 2] = self.cfg.rewards.base_height_target
+            dirs[0] = torch.tensor([math.cos(heading), math.sin(heading)], device=self.device)
+
+            for idx in range(1, self.cfg.traj.num_samples):
+                if torch.rand(1, device=self.device) < sharp_turn_prob:
+                    heading += torch_rand_float(-sharp_turn_angle, sharp_turn_angle, (1,), device=self.device)[0]
+                else:
+                    heading += torch_rand_float(-0.25, 0.25, (1,), device=self.device)[0]
+
+                speed_delta = torch_rand_float(-accel_max, accel_max, (1,), device=self.device)[0] * dt
+                speed = torch.clamp(speed + speed_delta, speed_min, speed_max)
+
+                dirs[idx] = torch.tensor([math.cos(heading), math.sin(heading)], device=self.device)
+                step = dirs[idx] * speed * dt
+                points[idx, 0:2] = points[idx - 1, 0:2] + step
+                points[idx, 2] = self.cfg.rewards.base_height_target
+
+    # ------------------------------------------------------------------
+    # 观测与奖励
+    # ------------------------------------------------------------------
     def compute_observations(self):
         super().compute_observations()
         if self.cfg.env.enableTaskObs:
-            # 添加轨迹观测
             rel_traj = self.traj_points - self.base_pos.unsqueeze(1)
-            traj_obs = rel_traj[:, :5].reshape(self.num_envs, -1)  # 前5个点
+            num_samples = min(5, self.cfg.traj.num_samples)
+            traj_obs = rel_traj[:, :num_samples].reshape(self.num_envs, -1)
             self.obs_buf = torch.cat([self.obs_buf, traj_obs], dim=-1)
-            
+            if self.privileged_obs_buf is not None:
+                self.privileged_obs_buf = torch.cat([self.privileged_obs_buf, traj_obs], dim=-1)
+
     def _reward_traj_tracking(self):
-        """轨迹跟踪奖励"""
-        # 找最近轨迹点
-        dists = torch.norm(self.traj_points[:, :, :2] - self.base_pos[:, :2].unsqueeze(1), dim=-1)
+        dists = torch.norm(
+            self.traj_points[:, :, :2] - self.base_pos[:, :2].unsqueeze(1),
+            dim=-1,
+        )
         min_dist = torch.min(dists, dim=1)[0]
         return torch.exp(-2.0 * min_dist)
-        
+
+    def _reward_traj_orientation(self):
+        # 取最近轨迹点的方向
+        dists = torch.norm(
+            self.traj_points[:, :, :2] - self.base_pos[:, :2].unsqueeze(1),
+            dim=-1,
+        )
+        nearest_idx = torch.argmin(dists, dim=1)
+        dirs = self.traj_dirs[torch.arange(self.num_envs, device=self.device), nearest_idx]
+        target_heading = torch.atan2(dirs[:, 1], dirs[:, 0])
+        base_heading = torch_utils.calc_heading_quat(self.base_quat)
+        diff = torch.abs(torch_utils.wrap_to_pi(base_heading - target_heading))
+        return torch.exp(-diff * 2.0)
+
+    def _reward_smooth_motion(self):
+        delta = torch.norm(self.actions - self.last_actions, dim=-1)
+        return torch.exp(-5.0 * delta)
+
+    # ------------------------------------------------------------------
+    # 状态更新
+    # ------------------------------------------------------------------
+    def reset_idx(self, env_ids):
+        super().reset_idx(env_ids)
+        if len(env_ids) == 0:
+            return
+        if not torch.is_tensor(env_ids):
+            env_ids = torch.as_tensor(env_ids, device=self.device, dtype=torch.long)
+        else:
+            env_ids = env_ids.to(self.device, dtype=torch.long)
+        self._generate_trajectories(env_ids)
+
     def post_physics_step(self):
         super().post_physics_step()
-        # 更新轨迹可视化标记
-        if self.cfg.traj.enable_markers and hasattr(self, 'update_markers'):
-            self.update_markers(self.traj_points[:, :self.num_markers])
+        if self.cfg.traj.enable_markers and hasattr(self, "update_markers"):
+            num_markers = min(self.num_markers, self.cfg.traj.num_samples)
+            self.update_markers(self.traj_points[:, :num_markers])


### PR DESCRIPTION
## Summary
- extend `LeggedRobot` with reusable helpers to support environments that create additional actors per environment
- rebuild the G1 carry, climb and sit interaction tasks on top of the new utilities, including proper observation, reset and reward logic
- refresh the G1 trajectory task with configurable trajectory sampling, richer observations and reward shaping

## Testing
- python -m compileall legged_gym/envs/g1

------
https://chatgpt.com/codex/tasks/task_e_68d39e7b8710832eb30b091cb5f6a0f7