### PR TITLE
Add progress buffer tracking for G1 traj env

### DIFF
--- a/legged_gym/envs/base/base_task.py
+++ b/legged_gym/envs/base/base_task.py
@@ -41,6 +41,7 @@ class BaseTask():
         self.obs_buf = torch.zeros(self.num_envs, self.num_obs, device=self.device, dtype=torch.float)
         self.rew_buf = torch.zeros(self.num_envs, device=self.device, dtype=torch.float)
         self.reset_buf = torch.ones(self.num_envs, device=self.device, dtype=torch.long)
+        self.progress_buf = torch.zeros(self.num_envs, device=self.device, dtype=torch.long)
         self.episode_length_buf = torch.zeros(self.num_envs, device=self.device, dtype=torch.long)
         self.time_out_buf = torch.zeros(self.num_envs, device=self.device, dtype=torch.bool)
         if self.num_privileged_obs is not None:

--- a/legged_gym/envs/base/legged_robot.py
+++ b/legged_gym/envs/base/legged_robot.py
@@ -104,6 +104,7 @@ class LeggedRobot(BaseTask):
         self.gym.refresh_net_contact_force_tensor(self.sim)
 
         self.episode_length_buf += 1
+        self.progress_buf += 1
         self.common_step_counter += 1
 
         # robot 根状态（all_root_states[:,0]）
@@ -158,6 +159,7 @@ class LeggedRobot(BaseTask):
         self.last_dof_vel[env_ids] = 0.
         self.feet_air_time[env_ids] = 0.
         self.episode_length_buf[env_ids] = 0
+        self.progress_buf[env_ids] = 0
         self.reset_buf[env_ids] = 1
 
         # 统计


### PR DESCRIPTION
## Summary
- add a `progress_buf` tensor to the legged task base class so per-environment step counts are tracked like in TokenHSI
- increment and reset the progress buffer from `LeggedRobot` so G1 trajectory tasks can derive time from it

## Testing
- python -m compileall legged_gym/envs/base/base_task.py legged_gym/envs/base/legged_robot.py

------
https://chatgpt.com/codex/tasks/task_e_68d4aaafac00832ea7f078b962210f2b